### PR TITLE
Debug output, tests and mixlib/shellout

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 LineLength:
-  Max: 100
+  Max: 150
 
 SpecialGlobalVars:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
+AllCops:
+  Exclude:
+    - 'test/**/*'
+
 LineLength:
-  Max: 150
+  Max: 100
 
 SpecialGlobalVars:
   Enabled: false

--- a/DOCS.md
+++ b/DOCS.md
@@ -1,4 +1,4 @@
-Use the chef plugin to deploy cookbooks to a Chef server.
+Drone plugin for deploying cookbooks to a Chef Server or Supermarket.
 
 Global Parameters
 =================
@@ -41,5 +41,5 @@ deploy:
     type: server
     org: my_org
     freeze: true
-    ssl_verify_mode: false
+    ssl_verify: false
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk update && \
     libffi-dev \
     bash && \
   gem install --no-ri --no-rdoc \
+    mixlib-shellout \
     chef \
     berkshelf \
     knife-supermarket && \

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 gem 'rspec', '~> 3.0', require: false, group: :test
 gem 'simplecov', require: false, group: :test
+gem 'mixlib-shellout', '~> 2.2'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# rubocop:disable LineLength, WordArray
+
 require 'json'
 require 'shellwords'
 
@@ -79,10 +81,15 @@ namespace :test do
     verbose(false) do
       puts 'Performing initial upload'
       sh "docker run -v #{cookbook_path}:/drone/src/github.com/drone/drone -i drone-plugins/drone-chef ARVG[0] #{Shellwords.escape(basic_config.to_json)}"
+      puts ''
+      puts 'Making sure cookbook was uploaded'
+      sh 'knife supermarket show drone-plugin-test'
+      puts ''
       puts 'Performing conflicting upload'
       sh "docker run -v #{cookbook_path}:/drone/src/github.com/drone/drone -i drone-plugins/drone-chef ARVG[0] #{Shellwords.escape(basic_config.to_json)}"
+      puts ''
       puts 'Performing conflicting upload with debug'
-      sh "docker run -v #{cookbook_path}:/drone/src/github.com/drone/drone -i drone-plugins/drone-chef ARVG[0] #{Shellwords.escape(basic_config.deep_merge({ 'vargs' => { 'debug' => true } }).to_json)}"
+      sh "docker run -v #{cookbook_path}:/drone/src/github.com/drone/drone -i drone-plugins/drone-chef ARVG[0] #{Shellwords.escape(basic_config.deep_merge('vargs' => { 'debug' => true }).to_json)} | grep DEBUG"
     end
   end
 end
@@ -90,4 +97,4 @@ end
 desc 'Test'
 task test: ['test:basic']
 
-task default: ['cleanup', 'build', 'test'] # rubocop:disable WordArray
+task default: ['cleanup', 'build', 'test']

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,93 @@
+require 'json'
+require 'shellwords'
+
+#
+# Override Hash class to add deep_merge method for recursive merging
+#
+class Hash
+  def deep_merge(second)
+    merger = proc { |_key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 } # rubocop:disable CaseEquality
+    merge(second, &merger)
+  end
+end
+
+# Parse common JSON for build from JSON file
+def common_json
+  @common ||= JSON.parse File.read 'test/common.json'
+end
+
+# @return the directory this Rakefile exists in
+def base_dir
+  File.dirname(__FILE__)
+end
+
+# @return the directory for our test cookbook
+def cookbook_path
+  "#{base_dir}/test/chef_cookbook"
+end
+
+# @return the user to auth with
+def user
+  ENV['CHEF_USER'] || fail('User not set')
+end
+
+# @return the key to auth with
+def key
+  ENV['CHEF_KEY'].tr("\\\\\n", "\n").gsub(/^n/, '') || fail('Key not set')
+end
+
+# @return [String] the server to upload to
+def server
+  ENV['CHEF_SERVER'] || fail('Server not set')
+end
+
+# @return [Hash] basic vargs to assume some defaults
+def basic_config
+  common_json.merge(
+    'vargs' => {
+      'user' => user,
+      'key' => key,
+      'server' => server,
+      'ssl_verify' => false
+    }
+  )
+end
+
+namespace :cleanup do
+  desc 'Unshare test cookbook'
+  task :cookbook do
+    sh 'knife supermarket unshare drone-plugin-test -y || exit 0'
+  end
+end
+
+desc 'Cleanup'
+task cleanup: ['cleanup:cookbook']
+
+namespace :build do
+  desc 'Build docker container'
+  task :docker do
+    sh 'docker build --rm=true -t drone-plugins/drone-chef .'
+  end
+end
+
+desc 'Build'
+task build: ['build:docker']
+
+namespace :test do
+  desc ''
+  task :basic do
+    verbose(false) do
+      puts 'Performing initial upload'
+      sh "docker run -v #{cookbook_path}:/drone/src/github.com/drone/drone -i drone-plugins/drone-chef ARVG[0] #{Shellwords.escape(basic_config.to_json)}"
+      puts 'Performing conflicting upload'
+      sh "docker run -v #{cookbook_path}:/drone/src/github.com/drone/drone -i drone-plugins/drone-chef ARVG[0] #{Shellwords.escape(basic_config.to_json)}"
+      puts 'Performing conflicting upload with debug'
+      sh "docker run -v #{cookbook_path}:/drone/src/github.com/drone/drone -i drone-plugins/drone-chef ARVG[0] #{Shellwords.escape(basic_config.deep_merge({ 'vargs' => { 'debug' => true } }).to_json)}"
+    end
+  end
+end
+
+desc 'Test'
+task test: ['test:basic']
+
+task default: ['cleanup', 'build', 'test'] # rubocop:disable WordArray

--- a/Rakefile
+++ b/Rakefile
@@ -76,7 +76,7 @@ desc 'Build'
 task build: ['build:docker']
 
 namespace :test do
-  desc ''
+  desc 'Perform basic cookbook upload tests'
   task :basic do
     verbose(false) do
       puts 'Performing initial upload'

--- a/lib/drone_chef/chef_server.rb
+++ b/lib/drone_chef/chef_server.rb
@@ -136,10 +136,6 @@ module DroneChef
       fail 'ERROR: knife upload failed' if cmd.error?
     end
 
-    def process_last_status
-      $?
-    end
-
     def cookbook
       @metadata ||= begin
         metadata = Chef::Cookbook::Metadata.new

--- a/lib/drone_chef/chef_server.rb
+++ b/lib/drone_chef/chef_server.rb
@@ -10,7 +10,7 @@ module DroneChef
     def initialize(config)
       @config = config
       @options = config.plugin_args
-      fail 'Chef organization required' unless @options.key? 'org'
+      fail 'ERROR: Chef organization required' unless @options.key? 'org'
     end
 
     def recursive
@@ -95,7 +95,7 @@ module DroneChef
       cmd = Mixlib::ShellOut.new("berks install -b #{@config.workspace}/Berksfile")
       cmd.run_command
 
-      fail 'Failed to retrieve cookbooks' if cmd.error?
+      fail 'ERROR: Failed to retrieve cookbooks' if cmd.error?
     end
 
     #
@@ -133,7 +133,7 @@ module DroneChef
       cmd.run_command
 
       puts "DEBUG: knife upload stdout: #{cmd.stdout}" if @config.debug?
-      fail 'knife upload failed' if cmd.error?
+      fail 'ERROR: knife upload failed' if cmd.error?
     end
 
     def process_last_status

--- a/lib/drone_chef/config.rb
+++ b/lib/drone_chef/config.rb
@@ -78,7 +78,7 @@ module DroneChef
     # Verify necessary data was provided
     #
     def verify_reqs
-      puts 'Verifying required arguments'
+      puts 'INFO: Verifying required arguments'
       fail 'No build data found' if @plugin_args.nil?
       fail 'Username required' unless @plugin_args.key? 'user'
       fail 'Key required' unless @plugin_args.key? 'key'
@@ -86,7 +86,7 @@ module DroneChef
     end
 
     def write_key
-      puts 'Writing temp key'
+      puts 'INFO: Writing temp key'
       File.open(key_path, 'w') do |f|
         f.write key
       end

--- a/lib/drone_chef/config.rb
+++ b/lib/drone_chef/config.rb
@@ -50,6 +50,10 @@ module DroneChef
       "#{Dir.home}/.chef/knife.rb"
     end
 
+    def debug?
+      @drone.debug?
+    end
+
     private
 
     #

--- a/lib/drone_chef/drone.rb
+++ b/lib/drone_chef/drone.rb
@@ -19,13 +19,20 @@ module DroneChef
       @data['vargs']
     end
 
-    def debug? # rubocop:disable AbcSize
-      return false if !!@data['vargs']['debug'] == @data['vargs']['debug'] # rubocop:disable DoubleNegation
-      return false if !!ENV['DEBUG'] == ENV['DEBUG'] # rubocop:disable DoubleNegation
-      @data['vargs']['debug'] || ENV['DEBUG']
+    def boolean?(arg)
+      !!arg == arg # rubocop:disable DoubleNegation
+    end
+
+    def debug?
+      return false unless boolean?(@data['vargs']['debug']) || env_debug?
+      @data['vargs']['debug'] || env_debug?
     end
 
     private
+
+    def env_debug?
+      ENV['DEBUG'] == 'true'
+    end
 
     def netrc
       @data['workspace']['netrc']

--- a/lib/drone_chef/drone.rb
+++ b/lib/drone_chef/drone.rb
@@ -19,6 +19,11 @@ module DroneChef
       @data['vargs']
     end
 
+    def debug?
+      return false if !!@data['vargs']['debug'] == @data['vargs']['debug'] # rubocop:disable DoubleNegation, LineLength
+      @data['vargs']['debug']
+    end
+
     private
 
     def netrc

--- a/lib/drone_chef/drone.rb
+++ b/lib/drone_chef/drone.rb
@@ -19,9 +19,10 @@ module DroneChef
       @data['vargs']
     end
 
-    def debug?
-      return false if !!@data['vargs']['debug'] == @data['vargs']['debug'] # rubocop:disable DoubleNegation, LineLength
-      @data['vargs']['debug']
+    def debug? # rubocop:disable AbcSize
+      return false if !!@data['vargs']['debug'] == @data['vargs']['debug'] # rubocop:disable DoubleNegation
+      return false if !!ENV['DEBUG'] == ENV['DEBUG'] # rubocop:disable DoubleNegation
+      @data['vargs']['debug'] || ENV['DEBUG']
     end
 
     private

--- a/lib/drone_chef/supermarket.rb
+++ b/lib/drone_chef/supermarket.rb
@@ -56,12 +56,13 @@ module DroneChef
       end
     end
 
-    def upload_command
+    def upload_command # rubocop:disable AbcSize
       command = ["knife supermarket share #{cookbook.name}"]
       command << "-c #{@config.knife_rb}"
       cmd = Mixlib::ShellOut.new(command.join(' '))
       cmd.run_command
-      puts cmd.stdout if @config.debug?
+      puts "DEBUG: knife supermarket share stdout: #{cmd.stdout}" if @config.debug?
+      puts "ERROR: knife supermarket share stderr: #{cmd.stderr}" if cmd.error?
       !cmd.error?
     end
 

--- a/lib/drone_chef/supermarket.rb
+++ b/lib/drone_chef/supermarket.rb
@@ -18,7 +18,7 @@ module DroneChef
       puts "INFO: Cookbook #{cookbook.name} version #{cookbook.version} " \
            "already uploaded to #{@config.server}" if uploaded?
       return if uploaded?
-      fail 'Failed to upload cookbook' unless upload_command
+      fail 'ERROR: Failed to upload cookbook' unless upload_command
     end
 
     def write_configs
@@ -29,8 +29,8 @@ module DroneChef
     private
 
     def verify_reqs
-      fail 'Missing cookbook metadata.rb' unless File.exist? "#{@config.workspace}/metadata.rb"
-      fail 'Missing cookbook README.md' unless File.exist? "#{@config.workspace}/README.md"
+      fail 'ERROR: Missing cookbook metadata.rb' unless File.exist? "#{@config.workspace}/metadata.rb"
+      fail 'ERROR: Missing cookbook README.md' unless File.exist? "#{@config.workspace}/README.md"
     end
 
     def write_knife_rb # rubocop:disable AbcSize

--- a/lib/drone_chef/supermarket.rb
+++ b/lib/drone_chef/supermarket.rb
@@ -1,5 +1,6 @@
 require 'pathname'
 require 'fileutils'
+require 'mixlib/shellout'
 
 module DroneChef
   #
@@ -58,8 +59,10 @@ module DroneChef
     def upload_command
       command = ["knife supermarket share #{cookbook.name}"]
       command << "-c #{@config.knife_rb}"
-      puts `#{command.join(' ')}`
-      process_last_status.success?
+      cmd = Mixlib::ShellOut.new(command.join(' '))
+      cmd.run_command
+      puts cmd.stdout if @config.debug?
+      !cmd.error?
     end
 
     def uploaded?
@@ -70,8 +73,9 @@ module DroneChef
       @cookbook_uploaded ||= begin
         command = ["knife supermarket show #{cookbook.name} #{cookbook.version}"]
         command << "-c #{@config.knife_rb}"
-        `#{command.join(' ')}`
-        process_last_status.success?
+        cmd = Mixlib::ShellOut.new(command.join(' '))
+        cmd.run_command
+        !cmd.error?
       end
     end
   end

--- a/lib/drone_chef/supermarket.rb
+++ b/lib/drone_chef/supermarket.rb
@@ -44,10 +44,6 @@ module DroneChef
       end
     end
 
-    def process_last_status
-      $?
-    end
-
     def cookbook
       @metadata ||= begin
         metadata = Chef::Cookbook::Metadata.new

--- a/lib/drone_chef/supermarket.rb
+++ b/lib/drone_chef/supermarket.rb
@@ -13,9 +13,9 @@ module DroneChef
     end
 
     def upload # rubocop:disable AbcSize
-      puts "Checking if #{cookbook.name}@#{cookbook.version} " \
+      puts "INFO: Checking if #{cookbook.name}@#{cookbook.version} " \
            "is already shared to #{@config.server}"
-      puts "Cookbook #{cookbook.name} version #{cookbook.version} " \
+      puts "INFO: Cookbook #{cookbook.name} version #{cookbook.version} " \
            "already uploaded to #{@config.server}" if uploaded?
       return if uploaded?
       fail 'Failed to upload cookbook' unless upload_command

--- a/lib/drone_chef/supermarket.rb
+++ b/lib/drone_chef/supermarket.rb
@@ -19,6 +19,7 @@ module DroneChef
            "already uploaded to #{@config.server}" if uploaded?
       return if uploaded?
       fail 'ERROR: Failed to upload cookbook' unless upload_command
+      puts "INFO: Finished uploading #{cookbook.name}@#{cookbook.version} to #{@config.server}"
     end
 
     def write_configs
@@ -72,6 +73,7 @@ module DroneChef
         command << "-c #{@config.knife_rb}"
         cmd = Mixlib::ShellOut.new(command.join(' '))
         cmd.run_command
+        puts "DEBUG: knife supermarket share stdout:\n#{cmd.stdout}" if @config.debug?
         !cmd.error?
       end
     end

--- a/spec/lib/drone_chef/chef_server_spec.rb
+++ b/spec/lib/drone_chef/chef_server_spec.rb
@@ -20,7 +20,6 @@ describe DroneChef::ChefServer do
     }
   end
   let(:file) { double('File') }
-  let(:process_status) { instance_double('Process::Status', success?: true) }
   let(:cookbook) do
     instance_double('Chef::Cookbook::Metadata', name: 'test_cookbook', version: '1.2.3')
   end
@@ -174,7 +173,6 @@ describe DroneChef::ChefServer do
       plugin_args.delete 'freeze'
       plugin_args.delete 'recursive'
 
-      allow(server).to receive(:process_last_status).and_return(process_status)
       allow(server).to receive(:cookbook).and_return(cookbook)
       allow(Dir).to receive(:exist?)
         .with('/path/to/project/{roles,environments,data_bags}')

--- a/spec/lib/drone_chef/chef_server_spec.rb
+++ b/spec/lib/drone_chef/chef_server_spec.rb
@@ -212,24 +212,24 @@ describe DroneChef::ChefServer do
     end
 
     context 'if not a cookbook' do
-      it 'uploads chef org data only when no cookbooks defined' do
-        # allow(File).to receive(:exist?).with('/path/to/project/metadata.rb').and_return(false)
-        # allow(File).to receive(:exist?).with('/path/to/project/Berksfile').and_return(false)
-        allow(server).to receive(:berksfile?).and_return(false)
+      before do
         allow(server).to receive(:cookbook?).and_return(false)
+      end
+
+      it 'uploads chef org data only when no cookbooks defined' do
+        allow(server).to receive(:berksfile?).and_return(false)
         allow(server).to receive(:chef_data?).and_return(true)
 
         expect(server).not_to receive(:berks_install)
         expect(server).not_to receive(:berks_upload)
         expect(Dir).to receive(:chdir).with('/path/to/project')
-        # expect(server).to receive(:`).with('knife upload . -c /root/.chef/knife.rb')
+        expect(knife_upload_shellout).to receive(:run_command)
         server.upload
       end
 
       it 'uploads chef org data and cookbooks' do
         allow(File).to receive(:exist?).with('/path/to/project/metadata.rb').and_return(false)
         allow(server).to receive(:berksfile?).and_return(true)
-        allow(server).to receive(:cookbook?).and_return(false)
         allow(server).to receive(:chef_data?).and_return(true)
 
         expect(server).to receive(:berks_install)
@@ -242,7 +242,6 @@ describe DroneChef::ChefServer do
       it 'does not upload chef org data if non exists' do
         allow(File).to receive(:exist?).with('/path/to/project/metadata.rb').and_return(false)
         allow(server).to receive(:berksfile?).and_return(false)
-        allow(server).to receive(:cookbook?).and_return(false)
         allow(server).to receive(:chef_data?).and_return(false)
 
         expect(knife_upload_shellout).not_to receive(:run_command)

--- a/spec/lib/drone_chef/chef_server_spec.rb
+++ b/spec/lib/drone_chef/chef_server_spec.rb
@@ -272,6 +272,17 @@ describe DroneChef::ChefServer do
         allow(knife_upload_shellout).to receive(:error?).and_return true
         expect { server.upload }.to raise_error('ERROR: knife upload failed')
       end
+
+      it 'does not give debug logs' do
+        allow(config).to receive(:debug?).and_return true
+        server.upload
+        expect($stdout.string).to match(/DEBUG/)
+      end
+
+      it 'does debug logs' do
+        server.upload
+        expect($stdout.string).not_to match(/DEBUG/)
+      end
     end
   end
 end

--- a/spec/lib/drone_chef/chef_server_spec.rb
+++ b/spec/lib/drone_chef/chef_server_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'drone_chef/config'
 require 'drone_chef/chef_server'
+require 'stringio'
 
 describe DroneChef::ChefServer do
   let(:server) { DroneChef::ChefServer.new config }
@@ -38,12 +39,8 @@ describe DroneChef::ChefServer do
   end
 
   before do
-    @original_stderr = $stderr
-    @original_stdout = $stdout
-
-    # Redirect stderr and stdout
-    $stderr = File.open(File::NULL, 'w')
-    $stdout = File.open(File::NULL, 'w')
+    $stdout = StringIO.new
+    $stderr = StringIO.new
 
     allow(File).to receive(:exist?).and_call_original
     allow(Dir).to receive(:exist?).and_call_original
@@ -61,8 +58,8 @@ describe DroneChef::ChefServer do
   end
 
   after do
-    $stderr = @original_stderr
-    $stdout = @original_stdout
+    $stdout = STDOUT
+    $stderr = STDERR
   end
 
   describe '#recursive' do

--- a/spec/lib/drone_chef/chef_server_spec.rb
+++ b/spec/lib/drone_chef/chef_server_spec.rb
@@ -259,6 +259,19 @@ describe DroneChef::ChefServer do
         allow(berks_install_shellout).to receive(:error?).and_return true
         expect { server.upload }.to raise_error('ERROR: Failed to retrieve cookbooks')
       end
+
+      it 'logs failure of uploading cookbooks' do
+        allow(berks_upload_shellout).to receive(:error?).and_return true
+        expect { server.upload }.to raise_error('ERROR: Failed to upload cookbook')
+      end
+
+      it 'logs failure of uploading chef org data' do
+        allow(server).to receive(:cookbook?).and_return(false)
+        allow(server).to receive(:chef_data?).and_return(true)
+        allow(Dir).to receive(:chdir).with('/path/to/project')
+        allow(knife_upload_shellout).to receive(:error?).and_return true
+        expect { server.upload }.to raise_error('ERROR: knife upload failed')
+      end
     end
   end
 end

--- a/spec/lib/drone_chef/supermarket_spec.rb
+++ b/spec/lib/drone_chef/supermarket_spec.rb
@@ -9,12 +9,22 @@ describe DroneChef::Supermarket do
                                          write_configs: nil, ssl_verify: false,
                                          knife_rb: '/root/.chef/knife.rb',
                                          server: 'https://myserver.com', user: 'johndoe',
-                                         key_path: '/tmp/key.pem', ssl_verify_mode: ':verify_none')
+                                         key_path: '/tmp/key.pem', ssl_verify_mode: ':verify_none',
+                                         debug?: false)
   end
   let(:file) { double('File') }
   let(:process_status) { instance_double('Process::Status', success?: true) }
   let(:cookbook) do
     instance_double('Chef::Cookbook::Metadata', name: 'test_cookbook', version: '1.2.3')
+  end
+
+  let(:knife_show_shellout) do
+    double('knife supermarket show test_cookbook',
+           run_command: nil, stdout: '00:00', error?: false)
+  end
+  let(:knife_share_shellout) do
+    double('knife supermarket share test_cookbook',
+           run_command: nil, stdout: '00:00', error?: false)
   end
 
   before do
@@ -30,6 +40,14 @@ describe DroneChef::Supermarket do
     allow(File).to receive(:exist?).with('/path/to/project/README.md').and_return(true)
     allow(server).to receive(:process_last_status).and_return(process_status)
     allow(server).to receive(:cookbook).and_return(cookbook)
+
+    # Stub shell commands
+    allow(Mixlib::ShellOut)
+      .to receive(:new).with('knife supermarket share test_cookbook -c /root/.chef/knife.rb')
+      .and_return(knife_share_shellout)
+    allow(Mixlib::ShellOut)
+      .to receive(:new).with('knife supermarket show test_cookbook 1.2.3 -c /root/.chef/knife.rb')
+      .and_return(knife_show_shellout)
   end
 
   after do
@@ -39,15 +57,13 @@ describe DroneChef::Supermarket do
 
   describe '#upload' do
     it 'checks if cookbook is already uploaded' do
-      expect(server).to receive(:`)
-        .with('knife supermarket show test_cookbook 1.2.3 -c /root/.chef/knife.rb')
+      expect(knife_show_shellout).to receive(:run_command)
       server.upload
     end
 
     it 'shares cookbook to supermarket' do
       allow(server).to receive(:knife_show).and_return(false)
-      expect(server).to receive(:`)
-        .with('knife supermarket share test_cookbook -c /root/.chef/knife.rb')
+      expect(knife_share_shellout).to receive(:run_command)
       server.upload
     end
 

--- a/spec/lib/drone_chef/supermarket_spec.rb
+++ b/spec/lib/drone_chef/supermarket_spec.rb
@@ -15,7 +15,6 @@ describe DroneChef::Supermarket do
                                          debug?: false)
   end
   let(:file) { double('File') }
-  let(:process_status) { instance_double('Process::Status', success?: true) }
   let(:cookbook) do
     instance_double('Chef::Cookbook::Metadata', name: 'test_cookbook', version: '1.2.3')
   end
@@ -36,7 +35,6 @@ describe DroneChef::Supermarket do
     allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?).with('/path/to/project/metadata.rb').and_return(true)
     allow(File).to receive(:exist?).with('/path/to/project/README.md').and_return(true)
-    allow(server).to receive(:process_last_status).and_return(process_status)
     allow(server).to receive(:cookbook).and_return(cookbook)
 
     # Stub shell commands

--- a/spec/lib/drone_chef/supermarket_spec.rb
+++ b/spec/lib/drone_chef/supermarket_spec.rb
@@ -98,7 +98,7 @@ describe DroneChef::Supermarket do
     it 'shows upload error' do
       allow(server).to receive(:knife_show).and_return(false) # Fake that cookbook was not uploaded
       allow(knife_share_shellout).to receive(:error?).and_return(true)
-      expect { server.upload }.to raise_error('Failed to upload cookbook')
+      expect { server.upload }.to raise_error('ERROR: Failed to upload cookbook')
       expect($stdout.string).to match(/share error/)
     end
 

--- a/test/chef_cookbook/Berksfile
+++ b/test/chef_cookbook/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/test/chef_cookbook/README.md
+++ b/test/chef_cookbook/README.md
@@ -1,0 +1,1 @@
+# drone-plugin-test

--- a/test/chef_cookbook/metadata.rb
+++ b/test/chef_cookbook/metadata.rb
@@ -1,0 +1,7 @@
+name             'drone-plugin-test'
+maintainer       'Jacob McCann'
+maintainer_email 'jacob.mccann2@target.com'
+license          'all_rights'
+description      'Cookbook to test drone-chef plugin'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'

--- a/test/common.json
+++ b/test/common.json
@@ -1,0 +1,36 @@
+{
+  "repo": {
+    "clone_url": "git://github.com/drone/drone",
+    "owner": "drone",
+    "name": "drone",
+    "full_name": "drone/drone"
+  },
+  "system": {
+    "link_url": "https://beta.drone.io"
+  },
+  "build": {
+    "number": 22,
+    "status": "success",
+    "started_at": 1421029603,
+    "finished_at": 1421029813,
+    "message": "Update the Readme",
+    "author": "johnsmith",
+    "author_email": "john.smith@gmail.com",
+    "event": "push",
+    "branch": "master",
+    "commit": "436b7a6e2abaddfd35740527353e78a227ddcb2c",
+    "ref": "refs/heads/master"
+  },
+  "workspace": {
+    "root": "/drone/src",
+    "path": "/drone/src/github.com/drone/drone",
+    "netrc": {
+      "machine": "",
+      "login": "",
+      "password": ""
+    }
+  },
+  "vargs": {
+    "debug": false
+  }
+}


### PR DESCRIPTION
So this started as me trying to cleanup logging and turned into a little more.

I also decided to replace backticks for executing shell commands with `mixlib/shellout` because that made testing of logging easier as well as doing the following for me which I was previously "doing by hand":
- Capture stdout
- Capture stderr
- Access return code from command

I added some additional unit tests, mainly around the logging.

Finally I added some super basic integration testing.  I created a Rakefile that will attempt to upload a simple cookbook to a supermarket.  It'll read values from ENV to know what server, user and key to use.
