### PR TITLE
Berkshelf fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN apk update && \
     chef \
     --version '~> 12.7' && \
   gem install --no-ri --no-rdoc \
+    io-console \
+    --version '~> 0.4' && \
+  gem install --no-ri --no-rdoc \
     berkshelf \
     --version '~> 4.2' && \
   gem install --no-ri --no-rdoc \

--- a/lib/drone/chef/processor.rb
+++ b/lib/drone/chef/processor.rb
@@ -104,8 +104,10 @@ module Drone
               .new("berks install -b #{config.workspace.path}/#{f}")
         cmd.run_command
 
-        logger.error cmd.stdout + cmd.stderr if cmd.error?
-        raise "ERROR: Failed to retrieve cookbooks" if cmd.error?
+        if cmd.error?
+          logger.error cmd.stdout + cmd.stderr
+          raise "ERROR: Failed to retrieve cookbooks"
+        end
       end
 
       #

--- a/lib/drone/chef/processor.rb
+++ b/lib/drone/chef/processor.rb
@@ -115,6 +115,7 @@ module Drone
               .new("berks install -b #{config.workspace.path}/#{f}")
         cmd.run_command
 
+        logger.error cmd.stdout + cmd.stderr if cmd.error?
         raise "ERROR: Failed to retrieve cookbooks" if cmd.error?
       end
 
@@ -137,6 +138,7 @@ module Drone
         cmd.run_command
 
         logger.debug "berks upload stdout: #{cmd.stdout}"
+        logger.error cmd.stdout + cmd.stderr if cmd.error?
         raise "ERROR: Failed to upload cookbook" if cmd.error?
       end
 

--- a/lib/drone/chef/processor.rb
+++ b/lib/drone/chef/processor.rb
@@ -47,15 +47,6 @@ module Drone
         knife_upload unless cookbook? || !chef_data?
       end
 
-      protected
-
-      #
-      # Are we uploading a cookbook?
-      #
-      def cookbook?
-        File.exist? "#{@config.workspace.path}/metadata.rb"
-      end
-
       #
       # Is there a Berksfile?
       #
@@ -66,6 +57,26 @@ module Drone
         end
         false
       end
+
+      protected
+
+      #
+      # Are we uploading a cookbook?
+      #
+      def cookbook?
+        File.exist? "#{@config.workspace.path}/metadata.rb"
+      end
+
+      # #
+      # # Is there a Berksfile?
+      # #
+      # def berksfile?
+      #   config.berks_files.each do |f|
+      #     return true if File.exist? "#{config.workspace.path}/#{f}"
+      #     return true if File.exist? "#{config.workspace.path}/#{f}.lock"
+      #   end
+      #   false
+      # end
 
       def url
         "#{@config.server}/organizations/#{@config.vargs["org"]}"

--- a/lib/drone/chef/processor.rb
+++ b/lib/drone/chef/processor.rb
@@ -67,17 +67,6 @@ module Drone
         File.exist? "#{@config.workspace.path}/metadata.rb"
       end
 
-      # #
-      # # Is there a Berksfile?
-      # #
-      # def berksfile?
-      #   config.berks_files.each do |f|
-      #     return true if File.exist? "#{config.workspace.path}/#{f}"
-      #     return true if File.exist? "#{config.workspace.path}/#{f}.lock"
-      #   end
-      #   false
-      # end
-
       def url
         "#{@config.server}/organizations/#{@config.vargs["org"]}"
       end

--- a/spec/lib/drone/chef/processor_spec.rb
+++ b/spec/lib/drone/chef/processor_spec.rb
@@ -103,6 +103,34 @@ describe Drone::Chef::Processor do
       end
     end
 
+    describe '#berksfile?' do
+      it "returns true if Berksfile exists" do
+        FakeFS do
+          FileUtils.mkdir_p "/path/to/project"
+          FileUtils.touch "/path/to/project/Berksfile"
+
+          expect(processor.berksfile?).to eq true
+        end
+      end
+
+      it "returns true if Berksfile.lock exists" do
+        FakeFS do
+          FileUtils.mkdir_p "/path/to/project"
+          FileUtils.touch "/path/to/project/Berksfile.lock"
+
+          expect(processor.berksfile?).to eq true
+        end
+      end
+
+      it "returns false otherwise" do
+        FakeFS do
+          FileUtils.mkdir_p "/path/to/project"
+
+          expect(processor.berksfile?).to eq false
+        end
+      end
+    end
+
     context "writes the knife config" do
       it "includes the username" do
         FakeFS do


### PR DESCRIPTION
This PR includes some fixes to get Berkshelf to run properly:
- Properly check for Berkshelf file paths to determine if we should run `berks`
- Install io-console gem due to error:

```
ERROR, [2016-05-23 19:02:17 +0000] : /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- io/console (LoadError)
    from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/shell/basic.rb:2:in `<top (required)>'
    from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/shell/color.rb:1:in `<top (required)>'
    from /usr/lib/ruby/gems/2.2.0/gems/thor-0.19.1/lib/thor/shell.rb:17:in `shell'
    from /usr/lib/ruby/gems/2.2.0/gems/berkshelf-4.3.2/lib/berkshelf/shell.rb:5:in `<module:Berkshelf>'
    from /usr/lib/ruby/gems/2.2.0/gems/berkshelf-4.3.2/lib/berkshelf/shell.rb:3:in `<top (required)>'
    from /usr/lib/ruby/gems/2.2.0/gems/berkshelf-4.3.2/lib/berkshelf.rb:59:in `ui'
    from /usr/lib/ruby/gems/2.2.0/gems/berkshelf-4.3.2/lib/berkshelf/base_generator.rb:22:in `<class:BaseGenerator>'
    from /usr/lib/ruby/gems/2.2.0/gems/berkshelf-4.3.2/lib/berkshelf/base_generator.rb:4:in `<module:Berkshelf>'
    from /usr/lib/ruby/gems/2.2.0/gems/berkshelf-4.3.2/lib/berkshelf/base_generator.rb:3:in `<top (required)>'
    from /usr/lib/ruby/gems/2.2.0/gems/berkshelf-4.3.2/lib/berkshelf.rb:192:in `require_relative'
    from /usr/lib/ruby/gems/2.2.0/gems/berkshelf-4.3.2/lib/berkshelf.rb:192:in `<top (required)>'
    from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /usr/lib/ruby/gems/2.2.0/gems/berkshelf-4.3.2/lib/berkshelf/cli.rb:1:in `<top (required)>'
    from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /usr/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
    from /usr/lib/ruby/gems/2.2.0/gems/berkshelf-4.3.2/bin/berks:3:in `<top (required)>'
    from /usr/bin/berks:23:in `load'
    from /usr/bin/berks:23:in `<main>'
```
